### PR TITLE
update host code of cl_wide_mem_rw_2x/4x 

### DIFF
--- a/ocl_kernels/cl_wide_mem_rw_2x/src/host.cpp
+++ b/ocl_kernels/cl_wide_mem_rw_2x/src/host.cpp
@@ -25,15 +25,37 @@
 // data size of the other examples
 #define DATA_SIZE (1024 * 1024) // * 2 * sizeof(int) = 8 MB
 
+// Number of HBM PCs required
+#define MAX_HBM_PC_COUNT 32
+#define PC_NAME(n) n | XCL_MEM_TOPOLOGY
+const int pc[MAX_HBM_PC_COUNT] = {
+    PC_NAME(0),  PC_NAME(1),  PC_NAME(2),  PC_NAME(3),  PC_NAME(4),  PC_NAME(5),  PC_NAME(6),  PC_NAME(7),
+    PC_NAME(8),  PC_NAME(9),  PC_NAME(10), PC_NAME(11), PC_NAME(12), PC_NAME(13), PC_NAME(14), PC_NAME(15),
+    PC_NAME(16), PC_NAME(17), PC_NAME(18), PC_NAME(19), PC_NAME(20), PC_NAME(21), PC_NAME(22), PC_NAME(23),
+    PC_NAME(24), PC_NAME(25), PC_NAME(26), PC_NAME(27), PC_NAME(28), PC_NAME(29), PC_NAME(30), PC_NAME(31)};
+
+#define MAX_DDR_PC_COUNT 2
+const int pc_ddr[MAX_DDR_PC_COUNT] = {
+    XCL_MEM_DDR_BANK0, XCL_MEM_DDR_BANK1 //, XCL_MEM_DDR_BANK2, XCL_MEM_DDR_BANK3
+};
+
 auto constexpr num_cu = 2;
+auto constexpr pc_per_cu = 4;
 
 int main(int argc, char** argv) {
-    if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " <XCLBIN File>" << std::endl;
+    if (argc != 3) {
+        std::cout << "Usage: " << argv[0] << " <XCLBIN File> <Memory Type: 0 (HBM) or 1 (DDR)>" << std::endl;
         return EXIT_FAILURE;
     }
 
     std::string binaryFile = argv[1];
+    std::string memoryType = argv[2];
+    auto ddr_flag = std::stoi(memoryType);
+
+    if(ddr_flag)
+      std::cout << "DDR is selected. " << std::endl;
+    else
+      std::cout << "HBM is selected. " << std::endl;
 
     // Allocate Memory in Host Memory
     int data_size = DATA_SIZE * num_cu;
@@ -48,6 +70,36 @@ int main(int argc, char** argv) {
         source_in2[i] = i * i;
         source_sw_results[i] = i * i + i;
         source_hw_results[i] = 0;
+    }
+
+    // For Allocating Buffer to specific Global Memory PC, user has to use
+    // cl_mem_ext_ptr_t
+    // and provide the PCs
+    std::vector<cl_mem_ext_ptr_t> inBufExt1(num_cu);
+    std::vector<cl_mem_ext_ptr_t> inBufExt2(num_cu);
+    std::vector<cl_mem_ext_ptr_t> outBufExt(num_cu);
+
+    for (int i = 0; i < num_cu; i++) {
+        inBufExt1[i].obj = source_in1.data() + (i * DATA_SIZE);
+        inBufExt1[i].param = 0;
+        if(ddr_flag)
+          inBufExt1[i].flags = pc_ddr[(i%MAX_DDR_PC_COUNT)];
+        else
+          inBufExt1[i].flags = pc[(i*(pc_per_cu))];
+
+        inBufExt2[i].obj = source_in2.data() + (i * DATA_SIZE);
+        inBufExt2[i].param = 0;
+        if(ddr_flag)
+          inBufExt2[i].flags = pc_ddr[(i%MAX_DDR_PC_COUNT)];
+        else
+          inBufExt2[i].flags = pc[(i*(pc_per_cu))+1];
+
+        outBufExt[i].obj = source_hw_results.data() + (i * DATA_SIZE);
+        outBufExt[i].param = 0;
+        if(ddr_flag)
+          outBufExt[i].flags = pc_ddr[(i%MAX_DDR_PC_COUNT)];
+        else
+          outBufExt[i].flags = pc[(i*(pc_per_cu))+2];
     }
 
     // OPENCL HOST CODE AREA START
@@ -68,7 +120,7 @@ int main(int argc, char** argv) {
         auto device = devices[i];
         // Creating Context and Command Queue for selected Device
         OCL_CHECK(err, context = cl::Context(device, nullptr, nullptr, nullptr, &err));
-        OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &err));
+        OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &err));
 
         std::cout << "Trying to program device[" << i << "]: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
         cl::Program program(context, {device}, bins, nullptr, &err);
@@ -97,30 +149,15 @@ int main(int argc, char** argv) {
     std::vector<cl::Buffer> buffer_output(num_cu);
 
     for (int i = 0; i < num_cu; i++) {
-        OCL_CHECK(err, buffer_in1[i]    = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-                                                     source_in1.data() + i * DATA_SIZE, &err));
-        OCL_CHECK(err, buffer_in2[i]    = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-                                                     source_in2.data() + i * DATA_SIZE, &err));
-        OCL_CHECK(err, buffer_output[i] = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY, vector_size_bytes,
-                                                     source_hw_results.data() + i * DATA_SIZE, &err));
+        OCL_CHECK(err, buffer_in1[i]    = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_EXT_PTR_XILINX | CL_MEM_USE_HOST_PTR, 
+                                                     vector_size_bytes, &inBufExt1[i], &err));
+        OCL_CHECK(err, buffer_in2[i]    = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_EXT_PTR_XILINX | CL_MEM_USE_HOST_PTR, 
+                                                     vector_size_bytes, &inBufExt2[i], &err));
+        OCL_CHECK(err, buffer_output[i] = cl::Buffer(context, CL_MEM_WRITE_ONLY | CL_MEM_EXT_PTR_XILINX | CL_MEM_USE_HOST_PTR, 
+                                                     vector_size_bytes, &outBufExt[i], &err));
     }
 
-    // OCL_CHECK(err, cl::Buffer buffer_in1(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-    //                                      source_in1.data(), &err));
-    // OCL_CHECK(err, cl::Buffer buffer_in2(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-    //                                      source_in2.data(), &err));
-    // OCL_CHECK(err, cl::Buffer buffer_output(context, CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY, vector_size_bytes,
-    //                                         source_hw_results.data(), &err));
-
-
     // Set the Kernel Arguments
-    // int size = DATA_SIZE;
-    // int nargs = 0;
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, buffer_in1));
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, buffer_in2));
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, buffer_output));
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, size));
-    std::cout << "test" << std::endl;
     int size = DATA_SIZE;
     for (int i = 0; i < num_cu; i++) {
         int narg = 0;
@@ -131,7 +168,6 @@ int main(int argc, char** argv) {
         OCL_CHECK(err, err = krnls[i].setArg(narg++, buffer_output[i]));
         OCL_CHECK(err, err = krnls[i].setArg(narg++, size));
     }
-    std::cout << "test" << std::endl;
 
     std::vector<cl::Event> event_kernel(num_cu);
     std::vector<cl::Event> event_data_to_fpga(num_cu);
@@ -153,7 +189,6 @@ int main(int argc, char** argv) {
         for (int i = 0; i < num_cu; i++) {
           OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_in1[i], buffer_in2[i]}, 0 /* 0 means from host*/, nullptr, &event_data_to_fpga[i]));
         }
-        // OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_in1, buffer_in2}, 0 /* 0 means from host*/, nullptr, &event_data_to_fpga));
         OCL_CHECK(err, err = q.finish());
         auto to_fpga_end = std::chrono::high_resolution_clock::now();
 
@@ -162,7 +197,6 @@ int main(int argc, char** argv) {
           // Launch the kernel
           OCL_CHECK(err, err = q.enqueueTask(krnls[i], nullptr, &event_kernel[i]));
         }
-        // OCL_CHECK(err, err = q.enqueueTask(krnl_vector_add, nullptr, &event_kernel));
         OCL_CHECK(err, err = q.finish());
         auto kernel_end = std::chrono::high_resolution_clock::now();
 
@@ -171,7 +205,6 @@ int main(int argc, char** argv) {
         for (int i = 0; i < num_cu; i++) {
           OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_output[i]}, CL_MIGRATE_MEM_OBJECT_HOST, nullptr, &event_data_to_host[i]));
         }
-        // OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_output}, CL_MIGRATE_MEM_OBJECT_HOST, nullptr, &event_data_to_host));
         OCL_CHECK(err, err = q.finish());
         auto from_fpga_end = std::chrono::high_resolution_clock::now();
 

--- a/ocl_kernels/cl_wide_mem_rw_4x/src/host.cpp
+++ b/ocl_kernels/cl_wide_mem_rw_4x/src/host.cpp
@@ -25,15 +25,37 @@
 // data size of the other examples
 #define DATA_SIZE (1024 * 1024) // * 2 * sizeof(int) = 8 MB
 
+// Number of HBM PCs required
+#define MAX_HBM_PC_COUNT 32
+#define PC_NAME(n) n | XCL_MEM_TOPOLOGY
+const int pc[MAX_HBM_PC_COUNT] = {
+    PC_NAME(0),  PC_NAME(1),  PC_NAME(2),  PC_NAME(3),  PC_NAME(4),  PC_NAME(5),  PC_NAME(6),  PC_NAME(7),
+    PC_NAME(8),  PC_NAME(9),  PC_NAME(10), PC_NAME(11), PC_NAME(12), PC_NAME(13), PC_NAME(14), PC_NAME(15),
+    PC_NAME(16), PC_NAME(17), PC_NAME(18), PC_NAME(19), PC_NAME(20), PC_NAME(21), PC_NAME(22), PC_NAME(23),
+    PC_NAME(24), PC_NAME(25), PC_NAME(26), PC_NAME(27), PC_NAME(28), PC_NAME(29), PC_NAME(30), PC_NAME(31)};
+
+#define MAX_DDR_PC_COUNT 2
+const int pc_ddr[MAX_DDR_PC_COUNT] = {
+    XCL_MEM_DDR_BANK0, XCL_MEM_DDR_BANK1 //, XCL_MEM_DDR_BANK2, XCL_MEM_DDR_BANK3
+};
+
 auto constexpr num_cu = 4;
+auto constexpr pc_per_cu = 4;
 
 int main(int argc, char** argv) {
-    if (argc != 2) {
-        std::cout << "Usage: " << argv[0] << " <XCLBIN File>" << std::endl;
+    if (argc != 3) {
+        std::cout << "Usage: " << argv[0] << " <XCLBIN File> <Memory Type: 0 (HBM) or 1 (DDR)>" << std::endl;
         return EXIT_FAILURE;
     }
 
     std::string binaryFile = argv[1];
+    std::string memoryType = argv[2];
+    auto ddr_flag = std::stoi(memoryType);
+
+    if(ddr_flag)
+      std::cout << "DDR is selected. " << std::endl;
+    else
+      std::cout << "HBM is selected. " << std::endl;
 
     // Allocate Memory in Host Memory
     int data_size = DATA_SIZE * num_cu;
@@ -48,6 +70,36 @@ int main(int argc, char** argv) {
         source_in2[i] = i * i;
         source_sw_results[i] = i * i + i;
         source_hw_results[i] = 0;
+    }
+
+    // For Allocating Buffer to specific Global Memory PC, user has to use
+    // cl_mem_ext_ptr_t
+    // and provide the PCs
+    std::vector<cl_mem_ext_ptr_t> inBufExt1(num_cu);
+    std::vector<cl_mem_ext_ptr_t> inBufExt2(num_cu);
+    std::vector<cl_mem_ext_ptr_t> outBufExt(num_cu);
+
+    for (int i = 0; i < num_cu; i++) {
+        inBufExt1[i].obj = source_in1.data() + (i * DATA_SIZE);
+        inBufExt1[i].param = 0;
+        if(ddr_flag)
+          inBufExt1[i].flags = pc_ddr[(i%MAX_DDR_PC_COUNT)];
+        else
+          inBufExt1[i].flags = pc[(i*(pc_per_cu))];
+
+        inBufExt2[i].obj = source_in2.data() + (i * DATA_SIZE);
+        inBufExt2[i].param = 0;
+        if(ddr_flag)
+          inBufExt2[i].flags = pc_ddr[(i%MAX_DDR_PC_COUNT)];
+        else
+          inBufExt2[i].flags = pc[(i*(pc_per_cu))+1];
+
+        outBufExt[i].obj = source_hw_results.data() + (i * DATA_SIZE);
+        outBufExt[i].param = 0;
+        if(ddr_flag)
+          outBufExt[i].flags = pc_ddr[(i%MAX_DDR_PC_COUNT)];
+        else
+          outBufExt[i].flags = pc[(i*(pc_per_cu))+2];
     }
 
     // OPENCL HOST CODE AREA START
@@ -68,8 +120,7 @@ int main(int argc, char** argv) {
         auto device = devices[i];
         // Creating Context and Command Queue for selected Device
         OCL_CHECK(err, context = cl::Context(device, nullptr, nullptr, nullptr, &err));
-        OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE, &err));
-        // OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &err));
+        OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &err));
 
         std::cout << "Trying to program device[" << i << "]: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
         cl::Program program(context, {device}, bins, nullptr, &err);
@@ -98,30 +149,18 @@ int main(int argc, char** argv) {
     std::vector<cl::Buffer> buffer_output(num_cu);
 
     for (int i = 0; i < num_cu; i++) {
-        OCL_CHECK(err, buffer_in1[i]    = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-                                                     source_in1.data() + i * DATA_SIZE, &err));
-        OCL_CHECK(err, buffer_in2[i]    = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-                                                     source_in2.data() + i * DATA_SIZE, &err));
-        OCL_CHECK(err, buffer_output[i] = cl::Buffer(context, CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY, vector_size_bytes,
-                                                     source_hw_results.data() + i * DATA_SIZE, &err));
+        // std::cout << "buffer_in1: " << inBufExt1[i].flags << std::endl;
+        OCL_CHECK(err, buffer_in1[i]    = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_EXT_PTR_XILINX | CL_MEM_USE_HOST_PTR, 
+                                                     vector_size_bytes, &inBufExt1[i], &err));
+        // std::cout << "buffer_in2: " << inBufExt2[i].flags << std::endl;
+        OCL_CHECK(err, buffer_in2[i]    = cl::Buffer(context, CL_MEM_READ_ONLY | CL_MEM_EXT_PTR_XILINX | CL_MEM_USE_HOST_PTR, 
+                                                     vector_size_bytes, &inBufExt2[i], &err));
+        // std::cout << "buffer_in3: " << outBufExt[i].flags << std::endl;
+        OCL_CHECK(err, buffer_output[i] = cl::Buffer(context, CL_MEM_WRITE_ONLY | CL_MEM_EXT_PTR_XILINX | CL_MEM_USE_HOST_PTR, 
+                                                     vector_size_bytes, &outBufExt[i], &err));
     }
 
-    // OCL_CHECK(err, cl::Buffer buffer_in1(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-    //                                      source_in1.data(), &err));
-    // OCL_CHECK(err, cl::Buffer buffer_in2(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
-    //                                      source_in2.data(), &err));
-    // OCL_CHECK(err, cl::Buffer buffer_output(context, CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY, vector_size_bytes,
-    //                                         source_hw_results.data(), &err));
-
-
     // Set the Kernel Arguments
-    // int size = DATA_SIZE;
-    // int nargs = 0;
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, buffer_in1));
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, buffer_in2));
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, buffer_output));
-    // OCL_CHECK(err, err = krnl_vector_add.setArg(nargs++, size));
-    std::cout << "test" << std::endl;
     int size = DATA_SIZE;
     for (int i = 0; i < num_cu; i++) {
         int narg = 0;
@@ -132,7 +171,6 @@ int main(int argc, char** argv) {
         OCL_CHECK(err, err = krnls[i].setArg(narg++, buffer_output[i]));
         OCL_CHECK(err, err = krnls[i].setArg(narg++, size));
     }
-    std::cout << "test" << std::endl;
 
     std::vector<cl::Event> event_kernel(num_cu);
     std::vector<cl::Event> event_data_to_fpga(num_cu);
@@ -154,7 +192,6 @@ int main(int argc, char** argv) {
         for (int i = 0; i < num_cu; i++) {
           OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_in1[i], buffer_in2[i]}, 0 /* 0 means from host*/, nullptr, &event_data_to_fpga[i]));
         }
-        // OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_in1, buffer_in2}, 0 /* 0 means from host*/, nullptr, &event_data_to_fpga));
         OCL_CHECK(err, err = q.finish());
         auto to_fpga_end = std::chrono::high_resolution_clock::now();
 
@@ -163,7 +200,6 @@ int main(int argc, char** argv) {
           // Launch the kernel
           OCL_CHECK(err, err = q.enqueueTask(krnls[i], nullptr, &event_kernel[i]));
         }
-        // OCL_CHECK(err, err = q.enqueueTask(krnl_vector_add, nullptr, &event_kernel));
         OCL_CHECK(err, err = q.finish());
         auto kernel_end = std::chrono::high_resolution_clock::now();
 
@@ -172,7 +208,6 @@ int main(int argc, char** argv) {
         for (int i = 0; i < num_cu; i++) {
           OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_output[i]}, CL_MIGRATE_MEM_OBJECT_HOST, nullptr, &event_data_to_host[i]));
         }
-        // OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_output}, CL_MIGRATE_MEM_OBJECT_HOST, nullptr, &event_data_to_host));
         OCL_CHECK(err, err = q.finish());
         auto from_fpga_end = std::chrono::high_resolution_clock::now();
 


### PR DESCRIPTION
update host code to explicitly select memory channels for buffer allocation. 
Need to pass an argument that represents the memory type: 0 for HBM and 1 for DDR. 